### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ reqwest = {version = "0.11.4", default-features = false, features = ["rustls-tls
 rust_decimal = "1.17.0"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"
-strum = {version = "0", features = ["derive"]}
+strum = {version = "0.24", features = ["derive"]}
 thiserror = "1.0.30"
 tracing = "0.1.35"
 url = {version = "2.2.2", features = ["serde"]}


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.