### PR TITLE
Switch crates.io publish to trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,25 +5,30 @@ on:
     tags:
       - v**
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: 🚀 Publish to crates.io
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - name: 🛠 Checkout
-        uses: actions/checkout@v2
-
-      - name: 📦 Install Cargo
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+        uses: actions/checkout@v5
 
       - name: 📦 Cargo clippy + build
         run: |
           cargo clippy -- -D warnings
           cargo build
 
+      - name: 🔐 Authenticate to crates.io
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
       - name: 🚀 Publish Crate
-        uses: katyo/publish-crates@v1
-        with:
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: |
+          cargo publish


### PR DESCRIPTION
## Summary
- Replace `katyo/publish-crates@v1` (which needs `CARGO_REGISTRY_TOKEN`) with `rust-lang/crates-io-auth-action@v1` + `cargo publish`, so the release workflow mints a short-lived token via OIDC instead of using a long-lived secret. Mirrors the pattern already in `chart-ext`.
- Add `id-token: write` on the publish job and a top-level `contents: read`.
- Bump `actions/checkout` v2 → v5.
- Drop the unmaintained `actions-rs/toolchain@v1` step — Rust is pre-installed on `ubuntu-latest`, consistent with `chart-ext` and `backend`.

## Follow-ups outside this PR
- On crates.io, configure a Trusted Publisher for this crate: owner `platzio`, repo `sdk-rs`, workflow `release.yml`.
- After the next tag publishes successfully, delete the `CARGO_REGISTRY_TOKEN` repo secret.

## Test plan
- [ ] Trusted publisher configured on crates.io for the crate(s) released from this repo
- [ ] Next `v*` tag triggers `release.yml` and `cargo publish` succeeds without `CARGO_REGISTRY_TOKEN`
- [ ] Remove the `CARGO_REGISTRY_TOKEN` secret once the above is confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)